### PR TITLE
Possibility to use ssh key authentication for git clone

### DIFF
--- a/roles/rhel_image/tasks/build_image.yml
+++ b/roles/rhel_image/tasks/build_image.yml
@@ -17,7 +17,6 @@
     dest: "{{ rhel_image_local_repo_path }}"
     version: "{{ rhel_image_git_repo_checkout }}"
     key_file: "{{ rhel_image_git_key_file }}"
-    force: yes
   when: rhel_image_git_key_file is defined
 
 - name: Push image blueprint to osbuilder

--- a/roles/rhel_image/tasks/build_image.yml
+++ b/roles/rhel_image/tasks/build_image.yml
@@ -9,16 +9,8 @@
     repo: "{{ rhel_image_git_remote_repo }}"
     dest: "{{ rhel_image_local_repo_path }}"
     version: "{{ rhel_image_git_repo_checkout }}"
-  when: rhel_image_git_key_file is not defined
-
-- name: Clone image blueprint repo with key
-  git:
-    repo: "{{ rhel_image_git_remote_repo }}"
-    dest: "{{ rhel_image_local_repo_path }}"
-    version: "{{ rhel_image_git_repo_checkout }}"
-    key_file: "{{ rhel_image_git_key_file }}"
-    accept_hostkey: true
-  when: rhel_image_git_key_file is defined
+    key_file: "{{ rhel_image_git_key_file | default(omit) }}"
+    accept_newhostkey: true
 
 - name: Push image blueprint to osbuilder
   command:

--- a/roles/rhel_image/tasks/build_image.yml
+++ b/roles/rhel_image/tasks/build_image.yml
@@ -17,6 +17,7 @@
     dest: "{{ rhel_image_local_repo_path }}"
     version: "{{ rhel_image_git_repo_checkout }}"
     key_file: "{{ rhel_image_git_key_file }}"
+    accept_hostkey: true
   when: rhel_image_git_key_file is defined
 
 - name: Push image blueprint to osbuilder

--- a/roles/rhel_image/tasks/build_image.yml
+++ b/roles/rhel_image/tasks/build_image.yml
@@ -9,6 +9,16 @@
     repo: "{{ rhel_image_git_remote_repo }}"
     dest: "{{ rhel_image_local_repo_path }}"
     version: "{{ rhel_image_git_repo_checkout }}"
+  when: rhel_image_git_key_file is not defined
+
+- name: Clone image blueprint repo with key
+  git:
+    repo: "{{ rhel_image_git_remote_repo }}"
+    dest: "{{ rhel_image_local_repo_path }}"
+    version: "{{ rhel_image_git_repo_checkout }}"
+    key_file: "{{ rhel_image_git_key_file }}"
+    force: yes
+  when: rhel_image_git_key_file is defined
 
 - name: Push image blueprint to osbuilder
   command:


### PR DESCRIPTION
Adding a variable rhel_image_git_key_file, if defined it will git clone with a supplied key file, otherwise use normal git clone.

Provides a safer and easy way to clone repositories which are private. 