### PR TITLE
Rename rhel_image_size_kb to rhel_image_size for consistency with com…

### DIFF
--- a/roles/rhel_image/README.md
+++ b/roles/rhel_image/README.md
@@ -52,7 +52,8 @@ rhel_image_build_remove: true
 
 # Image - only define needed options
 rhel_image_output_type: qcow2
-rhel_image_size_kb:
+rhel_image_size:  # (in MiB, not KiB)
+# Note: The variable was renamed from rhel_image_size_kb to rhel_image_size because according to the composer-cli documentation, the --size option is in MiB (megabytes), not KiB (kilobytes). Using the correct unit avoids confusion and potential build errors.
 rhel_image_ostree_ref:
 rhel_image_ostree_parent:
 rhel_image_ostree_url:

--- a/roles/rhel_image/defaults/main.yml
+++ b/roles/rhel_image/defaults/main.yml
@@ -41,7 +41,7 @@ rhel_image_build_remove: true
 
 # Image - only define needed options
 rhel_image_output_type: qcow2
-rhel_image_size_kb:
+rhel_image_size:
 rhel_image_ostree_ref:
 rhel_image_ostree_parent:
 rhel_image_ostree_url:

--- a/roles/rhel_image/tasks/build_image.yml
+++ b/roles/rhel_image/tasks/build_image.yml
@@ -30,8 +30,8 @@
     parent_option: "{{ ostree_parent | ternary('--parent ' + ostree_parent | string, '') }}"
     ostree_url: "{{ rhel_image_ostree_url | default(false) }}"
     url_option: "{{ ostree_url | ternary('--url ' + ostree_url | string, '') }}"
-    size_kb: "{{ rhel_image_size_kb | default(false) }}"
-    size_option: "{{ size_kb | ternary('--size ' + size_kb | string, '') }}"
+    size_mb: "{{ rhel_image_size | default(false) }}"
+    size_option: "{{ size_mb | ternary('--size ' + size_mb | string, '') }}"
     start_cmd: "{{ 'start-ostree' if ostree_ref else 'start' }}"
   ansible.builtin.command: >
     composer-cli compose {{ start_cmd }} {{ ref_option }} {{ parent_option }} {{ url_option }} {{ size_option }}


### PR DESCRIPTION
This pull request updates the variable name and unit for specifying image size in the RHEL image build process to align with the `composer-cli` documentation. The changes ensure consistency and prevent potential build errors caused by unit mismatches.

### Variable renaming and unit update:

* [`roles/rhel_image/README.md`](diffhunk://#diff-18983d908ae138d768614be7cb7c403cabaf0540cfd68b33949273623f90ca29L55-R56): Renamed the variable `rhel_image_size_kb` to `rhel_image_size` and clarified that the unit is now in MiB (megabytes) instead of KiB (kilobytes). Added a note to explain the change and its reasoning.
* [`roles/rhel_image/defaults/main.yml`](diffhunk://#diff-8f9369dc75eb8329c20eeb0116803bd93176fb5b46e7524b5a2f7c3981b36c9cL44-R44): Updated the default variable name from `rhel_image_size_kb` to `rhel_image_size`.
* [`roles/rhel_image/tasks/build_image.yml`](diffhunk://#diff-0cccd7babc9e469cdaa36fea50a65a98710981684238b7b3246632b595f70d5aL33-R34): Modified the task to use `rhel_image_size` instead of `rhel_image_size_kb` and updated the logic to handle the new variable and its unit correctly.…poser-cli documentation